### PR TITLE
Fix broken ssl in urllib3 under python 2.7.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,9 @@ setup(
         'requests-cache>=0.4.7',
         'grequests==0.2.0',
         'easydict',
+        'pyopenssl',
+        'ndg-httpsclient',
+        'pyasn1'
     ],
     tests_require = ['pytest-timeout'],
     classifiers=['Development Status :: 4 - Beta',


### PR DESCRIPTION
To avoid "'TypeError: **init**() got an unexpected keyword argument 'server_hostname'" in python 2.7.9, pyopenssl, ndg-httpsclient and pyasn1 necessary to be installed.
