### PR TITLE
Check default format for svg+xml

### DIFF
--- a/chembl_webresource_client/new_client.py
+++ b/chembl_webresource_client/new_client.py
@@ -55,7 +55,7 @@ def client_from_url(url, base_url=None):
             continue
         model = Model(name, collection_name, formats, searchable)
         qs = QuerySet(model=model)
-        if default_format in ('xml', 'image/svg+xml'):
+        if default_format not in ('xml', 'svg+xml'):
             qs.set_format(default_format)
         setattr(client, name, qs)
 


### PR DESCRIPTION
This will resolve #71 and allow for parsing xml data as before.

For example the command:
```python3
new_client.target.only(['organism'])[0]['organism']
```
 currently throws an exception due to the response being a xml string, rather than a dictionary.