### PR TITLE
[Docs] Diagram representation of the chembl_webresource_client

### DIFF
--- a/.codeboarding/ChEMBL_Core_API_Client.md
+++ b/.codeboarding/ChEMBL_Core_API_Client.md
@@ -1,0 +1,257 @@
+```mermaid
+
+graph LR
+
+    ChEMBLClientFactory["ChEMBLClientFactory"]
+
+    Query["Query"]
+
+    UrlQuery["UrlQuery"]
+
+    QuerySet["QuerySet"]
+
+    ElasticClient["ElasticClient"]
+
+    Settings["Settings"]
+
+    SporeClient["SporeClient"]
+
+    Singleton["Singleton"]
+
+    HttpErrors["HttpErrors"]
+
+    Utils["Utils"]
+
+    ChEMBLClientFactory -- "creates" --> QuerySet
+
+    ChEMBLClientFactory -- "uses" --> Settings
+
+    Query -- "is inherited by" --> UrlQuery
+
+    Query -- "is inherited by" --> ElasticClient
+
+    UrlQuery -- "inherits from" --> QuerySet
+
+    UrlQuery -- "uses" --> Settings
+
+    UrlQuery -- "handles" --> HttpErrors
+
+    QuerySet -- "uses" --> UrlQuery
+
+    QuerySet -- "uses" --> Settings
+
+    ElasticClient -- "uses" --> Settings
+
+    SporeClient -- "executes requests for" --> UrlQuery
+
+    SporeClient -- "uses" --> Settings
+
+    SporeClient -- "raises" --> HttpErrors
+
+    Settings -- "uses" --> Singleton
+
+    Utils -- "supports" --> QuerySet
+
+    Utils -- "uses" --> SporeClient
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+This overview details the core components of the ChEMBL Core API Client, focusing on their structure, flow, and purpose. These components are fundamental to how the client interacts with the ChEMBL REST API, from initiating requests to handling responses and errors.
+
+
+
+### ChEMBLClientFactory
+
+This component serves as the primary entry point for users to obtain and configure instances of the ChEMBL API client. It orchestrates the creation of client objects that expose a high-level, chainable interface for API interactions. It's fundamental because it's the user's gateway to the entire client functionality.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `ChEMBLClientFactory` (0:0)
+
+
+
+
+
+### Query
+
+A foundational abstract class that defines the basic structure and behavior for constructing and managing API queries. It acts as a base for more specialized query types, ensuring a consistent interface for query building across the client. It's fundamental as it establishes the common contract for all query operations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/query.py#L7-L35" target="_blank" rel="noopener noreferrer">`Query` (7:35)</a>
+
+
+
+
+
+### UrlQuery
+
+A specialized query handler that extends the capabilities of `Query` and `QuerySet`. It is specifically designed to construct and execute queries tailored for URL-based interactions with the REST API, managing aspects like URL parameters, filtering, and pagination. It's fundamental for handling the specifics of RESTful API queries.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/url_query.py#L19-L444" target="_blank" rel="noopener noreferrer">`UrlQuery` (19:444)</a>
+
+
+
+
+
+### QuerySet
+
+A core component that provides mechanisms for managing collections of query results and enabling the chaining of multiple query operations. It facilitates complex data retrieval patterns by allowing queries to be combined, filtered, and iterated over efficiently. It's fundamental for handling and manipulating API responses as collections.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/query_set.py#L21-L265" target="_blank" rel="noopener noreferrer">`QuerySet` (21:265)</a>
+
+
+
+
+
+### ElasticClient
+
+The primary client interface for performing search operations against the ChEMBL web resource. It provides high-level methods for searching various entities (e.g., molecules, targets, assays) and encapsulates the logic for executing these searches. Its inheritance from `Query` suggests it also offers direct query-building capabilities. It's fundamental for the core search functionality of the ChEMBL API.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/elastic_client.py#L5-L47" target="_blank" rel="noopener noreferrer">`ElasticClient` (5:47)</a>
+
+
+
+
+
+### Settings
+
+A centralized component responsible for managing global settings and configurations for the entire ChEMBL web resource client. This includes critical parameters such as API endpoints, default timeouts, and other configurable options, ensuring consistent behavior across all client components. It's fundamental for maintaining consistent and configurable client behavior.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/settings.py#L10-L41" target="_blank" rel="noopener noreferrer">`Settings` (10:41)</a>
+
+
+
+
+
+### SporeClient
+
+This component is responsible for the low-level execution of HTTP requests, handling the direct communication with the ChEMBL REST API. It likely wraps an underlying HTTP library to manage connections, send requests, and receive responses. It's fundamental as it's the actual communication layer with the ChEMBL API.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/spore_client.py#L0-L0" target="_blank" rel="noopener noreferrer">`SporeClient` (0:0)</a>
+
+
+
+
+
+### Singleton
+
+A utility component that provides a mechanism to ensure that specific classes or objects within the client have only one instance throughout the application's lifecycle. This is crucial for managing shared resources like configurations or core client instances, preventing inconsistencies. It's fundamental for managing shared resources efficiently.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/singleton.py#L2-L42" target="_blank" rel="noopener noreferrer">`Singleton` (2:42)</a>
+
+
+
+
+
+### HttpErrors
+
+Defines a set of custom exception classes for various HTTP error codes. This component provides a structured and specific way to handle and propagate errors encountered during API interactions, enhancing the client's robustness and error reporting. It's fundamental for robust error handling and clear communication of API issues.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/http_errors.py#L0-L0" target="_blank" rel="noopener noreferrer">`HttpErrors` (0:0)</a>
+
+
+
+
+
+### Utils
+
+A collection of general utility functions that support various operations across the client. This component includes helper functions for data manipulation, API response processing, and other common functionalities that are essential for the overall operation of the client. It's fundamental as it provides common helper functions used throughout the client.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/utils.py#L0-L0" target="_blank" rel="noopener noreferrer">`Utils` (0:0)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Data_Transformation_Utilities.md
+++ b/.codeboarding/Data_Transformation_Utilities.md
@@ -1,0 +1,213 @@
+```mermaid
+
+graph LR
+
+    Data_Transformation_Utilities["Data Transformation Utilities"]
+
+    ChEMBL_API_Client["ChEMBL API Client"]
+
+    ElasticSearch_Client["ElasticSearch Client"]
+
+    Query_Abstraction["Query Abstraction"]
+
+    Core_Infrastructure_Utilities["Core Infrastructure Utilities"]
+
+    HTTP_Error_Handling["HTTP Error Handling"]
+
+    UniChem_Client["UniChem Client"]
+
+    Data_Transformation_Utilities -- "uses" --> ChEMBL_API_Client
+
+    Data_Transformation_Utilities -- "uses" --> ElasticSearch_Client
+
+    Data_Transformation_Utilities -- "uses" --> Core_Infrastructure_Utilities
+
+    Data_Transformation_Utilities -- "uses" --> UniChem_Client
+
+    ChEMBL_API_Client -- "uses" --> Query_Abstraction
+
+    ChEMBL_API_Client -- "raises/handles" --> HTTP_Error_Handling
+
+    ElasticSearch_Client -- "inherits from" --> Query_Abstraction
+
+    ElasticSearch_Client -- "uses" --> Core_Infrastructure_Utilities
+
+    Query_Abstraction -- "uses" --> HTTP_Error_Handling
+
+    Query_Abstraction -- "uses" --> Core_Infrastructure_Utilities
+
+    UniChem_Client -- "uses" --> Core_Infrastructure_Utilities
+
+    UniChem_Client -- "raises/handles" --> HTTP_Error_Handling
+
+    click Data_Transformation_Utilities href "https://github.com/chembl/chembl_webresource_client/blob/master/.codeboarding//Data_Transformation_Utilities.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Data Transformation Utilities` component is a critical part of the `chembl_webresource_client` project, serving as the backbone for data manipulation, identifier resolution, and various transformations related to ChEMBL data. It is fundamental because it encapsulates the core logic required by the command-line scripts to interact with and process chemical and biological data from the ChEMBL database and related services.
+
+
+
+### Data Transformation Utilities [[Expand]](./Data_Transformation_Utilities.md)
+
+This component provides the core logic for data manipulation, identifier resolution, and various transformations of ChEMBL data, along with the command-line interfaces to execute these operations. It includes serializers for different data formats (e.g., SMILES, InChI, ChEMBL IDs) and functions for converting between molecules and targets.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/scripts/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.scripts.utils` (1:1)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/scripts/chembl_act.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.scripts.chembl_act` (1:1)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/scripts/chembl_ids.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.scripts.chembl_ids` (1:1)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/scripts/chembl_m2t.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.scripts.chembl_m2t` (1:1)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/scripts/chembl_sim.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.scripts.chembl_sim` (1:1)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/scripts/chembl_sub.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.scripts.chembl_sub` (1:1)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/scripts/chembl_t2m.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.scripts.chembl_t2m` (1:1)</a>
+
+
+
+
+
+### ChEMBL API Client
+
+This component serves as the primary interface for interacting with the ChEMBL web API. It handles making HTTP requests, parsing responses, and providing a higher-level, structured interface to access ChEMBL data programmatically.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/new_client.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.new_client` (1:1)</a>
+
+
+
+
+
+### ElasticSearch Client
+
+This component provides a direct interface for querying the underlying ChEMBL data store, which is likely an Elasticsearch instance. It offers methods to search for specific chemical and biological entities, abstracting the complexities of the search engine.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/elastic_client.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.elastic_client` (1:1)</a>
+
+
+
+
+
+### Query Abstraction
+
+These are foundational base classes that provide an abstract framework for constructing and managing queries and query results. They define the basic interface for a query and functionalities for handling collections of query results or chaining queries, often integrating with HTTP error handling.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/query.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.query` (1:1)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/query_set.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.query_set` (1:1)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/url_query.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.url_query` (1:1)</a>
+
+
+
+
+
+### Core Infrastructure Utilities
+
+This component provides fundamental, low-level utilities and configurations essential for the entire client. It includes settings management, singleton patterns for shared resources, and a client for the Spore API, which might be used for API discovery or interaction.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/settings.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.settings` (1:1)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/singleton.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.singleton` (1:1)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.utils` (1:1)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/spore_client.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.spore_client` (1:1)</a>
+
+
+
+
+
+### HTTP Error Handling
+
+This module defines a hierarchy of custom exception classes for various HTTP error codes (e.g., 404 Not Found, 400 Bad Request). These exceptions are crucial for robust error management, allowing the client to gracefully handle issues related to HTTP communication with web services.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/http_errors.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.http_errors` (1:1)</a>
+
+
+
+
+
+### UniChem Client
+
+This specialized component is designed to interact with the UniChem web service, which provides cross-references between chemical structures and their identifiers across various public databases. It handles UniChem-specific API calls and error handling.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/unichem.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.unichem` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Elasticsearch_Search_Client.md
+++ b/.codeboarding/Elasticsearch_Search_Client.md
@@ -1,0 +1,113 @@
+```mermaid
+
+graph LR
+
+    ElasticClient["ElasticClient"]
+
+    Query["Query"]
+
+    UrlQuery["UrlQuery"]
+
+    QuerySet["QuerySet"]
+
+    ElasticClient -- "inherits from" --> Query
+
+    UrlQuery -- "inherits from" --> Query
+
+    UrlQuery -- "inherits from" --> QuerySet
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+This subsystem provides a dedicated interface for performing searches across various ChEMBL entities (e.g., molecules, targets) leveraging an Elasticsearch backend. Its core functionality revolves around defining, executing, and managing search queries and their results.
+
+
+
+### ElasticClient
+
+The primary client interface for performing searches across various ChEMBL entities using an Elasticsearch backend. It provides high-level methods for searching molecules, targets, assays, etc., and internally orchestrates these search operations by utilizing its inherited `Query` capabilities and its internal `_search` method. It serves as the main entry point for Elasticsearch-based search operations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/elastic_client.py#L5-L47" target="_blank" rel="noopener noreferrer">`ElasticClient` (5:47)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/elastic_client.py#L10-L29" target="_blank" rel="noopener noreferrer">`ElasticClient:_search` (10:29)</a>
+
+
+
+
+
+### Query
+
+A foundational abstract class that defines the basic structure and behavior for constructing and managing search queries. It establishes the common interface and basic parameters for any search request, serving as a base for more specialized query types.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/query.py#L7-L35" target="_blank" rel="noopener noreferrer">`Query` (7:35)</a>
+
+
+
+
+
+### UrlQuery
+
+A specialized query handler that extends both `Query` and `QuerySet` functionalities. It is specifically designed to construct and execute queries for URL-based interactions with the ChEMBL web resource, handling aspects like pagination, filtering, and result iteration. This component bridges the gap between generic query definition and web-specific query execution.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/url_query.py#L19-L444" target="_blank" rel="noopener noreferrer">`UrlQuery` (19:444)</a>
+
+
+
+
+
+### QuerySet
+
+A base class that provides mechanisms for managing collections of query results and enabling chained query operations. It allows for more complex data retrieval patterns by facilitating iteration over results and combining multiple query steps, crucial for handling paginated or large datasets from the web resource.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/query_set.py#L21-L265" target="_blank" rel="noopener noreferrer">`QuerySet` (21:265)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/UniChem_Cross_Referencing_Client.md
+++ b/.codeboarding/UniChem_Cross_Referencing_Client.md
@@ -1,0 +1,95 @@
+```mermaid
+
+graph LR
+
+    UniChem_Cross_Referencing_Client["UniChem Cross-Referencing Client"]
+
+    Client_Settings["Client Settings"]
+
+    HTTP_Error_Handling["HTTP Error Handling"]
+
+    UniChem_Cross_Referencing_Client -- "Uses" --> Client_Settings
+
+    UniChem_Cross_Referencing_Client -- "Handles Errors With" --> HTTP_Error_Handling
+
+    Client_Settings -- "Used By" --> UniChem_Cross_Referencing_Client
+
+    HTTP_Error_Handling -- "Used By" --> UniChem_Cross_Referencing_Client
+
+    click UniChem_Cross_Referencing_Client href "https://github.com/chembl/chembl_webresource_client/blob/master/.codeboarding//UniChem_Cross_Referencing_Client.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+This document describes the UniChem Cross-Referencing Client and its fundamental components and their interactions. It covers the core client, configuration settings, and HTTP error handling, highlighting their roles in providing robust cross-referencing capabilities.
+
+
+
+### UniChem Cross-Referencing Client [[Expand]](./UniChem_Cross_Referencing_Client.md)
+
+The core of this subsystem, responsible for all interactions with the UniChem web service. It encapsulates the logic for making API calls, handling responses, and managing the HTTP session.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/unichem.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.unichem` (1:1)</a>
+
+
+
+
+
+### Client Settings
+
+Manages global configuration settings for the ChEMBL web resource client, including API URLs, timeouts, caching parameters, and proxy settings.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/settings.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.settings` (1:1)</a>
+
+
+
+
+
+### HTTP Error Handling
+
+Defines a hierarchy of custom exception classes for various HTTP error codes (e.g., HttpNotFound, HttpBadRequest).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/http_errors.py#L1-L1" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.http_errors` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,149 @@
+```mermaid
+
+graph LR
+
+    ChEMBL_Core_API_Client["ChEMBL Core API Client"]
+
+    Elasticsearch_Search_Client["Elasticsearch Search Client"]
+
+    UniChem_Cross_Referencing_Client["UniChem Cross-Referencing Client"]
+
+    Data_Transformation_Utilities["Data Transformation Utilities"]
+
+    ChEMBL_Core_API_Client -- "Initializes" --> Elasticsearch_Search_Client
+
+    ChEMBL_Core_API_Client -- "Initializes" --> UniChem_Cross_Referencing_Client
+
+    Elasticsearch_Search_Client -- "Utilizes" --> ChEMBL_Core_API_Client
+
+    UniChem_Cross_Referencing_Client -- "Utilizes" --> ChEMBL_Core_API_Client
+
+    Data_Transformation_Utilities -- "Processes Data From" --> ChEMBL_Core_API_Client
+
+    Data_Transformation_Utilities -- "Queries" --> Elasticsearch_Search_Client
+
+    click ChEMBL_Core_API_Client href "https://github.com/chembl/chembl_webresource_client/blob/master/.codeboarding//ChEMBL_Core_API_Client.md" "Details"
+
+    click Elasticsearch_Search_Client href "https://github.com/chembl/chembl_webresource_client/blob/master/.codeboarding//Elasticsearch_Search_Client.md" "Details"
+
+    click UniChem_Cross_Referencing_Client href "https://github.com/chembl/chembl_webresource_client/blob/master/.codeboarding//UniChem_Cross_Referencing_Client.md" "Details"
+
+    click Data_Transformation_Utilities href "https://github.com/chembl/chembl_webresource_client/blob/master/.codeboarding//Data_Transformation_Utilities.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+Final architecture analysis for `chembl_webresource_client`
+
+
+
+### ChEMBL Core API Client [[Expand]](./ChEMBL_Core_API_Client.md)
+
+This is the central component for interacting with the main ChEMBL REST API. It manages client instances, provides a high-level, chainable interface for building and executing queries, and handles the low-level HTTP request execution, including URL construction and pagination.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/new_client.py#L0-L0" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.new_client` (0:0)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/spore_client.py#L0-L0" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.spore_client` (0:0)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/singleton.py#L0-L0" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.singleton` (0:0)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/settings.py#L0-L0" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.settings` (0:0)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/query_set.py#L0-L0" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.query_set` (0:0)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/url_query.py#L0-L0" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.url_query` (0:0)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/query.py#L0-L0" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.query` (0:0)</a>
+
+
+
+
+
+### Elasticsearch Search Client [[Expand]](./Elasticsearch_Search_Client.md)
+
+This component provides a dedicated interface for performing searches across various ChEMBL entities (e.g., molecules, targets) leveraging an Elasticsearch backend.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/elastic_client.py#L0-L0" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.elastic_client` (0:0)</a>
+
+
+
+
+
+### UniChem Cross-Referencing Client [[Expand]](./UniChem_Cross_Referencing_Client.md)
+
+This component specializes in interacting with the UniChem web service, enabling cross-referencing of chemical identifiers from diverse external sources.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/unichem.py#L0-L0" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.unichem` (0:0)</a>
+
+
+
+
+
+### Data Transformation Utilities [[Expand]](./Data_Transformation_Utilities.md)
+
+This component comprises a collection of helper functions and scripts designed for data manipulation, resolution of identifiers, and various transformations related to ChEMBL data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/scripts/utils.py#L0-L0" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.scripts.utils` (0:0)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/scripts/chembl_act.py#L0-L0" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.scripts.chembl_act` (0:0)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/scripts/chembl_ids.py#L0-L0" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.scripts.chembl_ids` (0:0)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/scripts/chembl_m2t.py#L0-L0" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.scripts.chembl_m2t` (0:0)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/scripts/chembl_sim.py#L0-L0" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.scripts.chembl_sim` (0:0)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/scripts/chembl_sub.py#L0-L0" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.scripts.chembl_sub` (0:0)</a>
+
+- <a href="https://github.com/chembl/chembl_webresource_client/chembl_webresource_client/scripts/chembl_t2m.py#L0-L0" target="_blank" rel="noopener noreferrer">`chembl_webresource_client.scripts.chembl_t2m` (0:0)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR adds an architectural diagram of the chembl_webresource_client codebase to help new contributors quickly understand its structure.

You can see how the change renders here: https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/chembl_webresource_client/on_boarding.md

I would love to hear what do you think of auto generate diagram first documentation. This way it can always be up-to-date, (generated with Static Analysis and LLMs) if you like what you see I'd be more than happy to also make a PR with our free to use github action :)

Since Discussions aren’t enabled, I’m sharing this via PR.

Disclamer: We're doing this as part of an early-stage startup, exploring what’s most helpful for OSS maintainers.