### PR TITLE
Replace deprecated pkg_resources with importlib

### DIFF
--- a/chembl_webresource_client/__init__.py
+++ b/chembl_webresource_client/__init__.py
@@ -1,7 +1,9 @@
+from importlib.metadata import version
+
 __author__ = 'mnowotka'
 
 try:
-    __version__ = __import__('pkg_resources').get_distribution('chembl_webresource_client').version
+    __version__ = version('chembl_webresource_client')
 except Exception as e:
     __version__ = 'development'
 


### PR DESCRIPTION
This replaces the depracated `pkg_resources` with `importlib`. A screenshot of the deprecation warning is shown below:

<img width="1349" height="174" alt="deprecation-warning" src="https://github.com/user-attachments/assets/ea0948d0-ebab-4273-b671-23ef6d8d8155" />
