### PR TITLE
Fix broken demo_wrc notebook by renaming target "hERG"

### DIFF
--- a/demo_wrc.ipynb
+++ b/demo_wrc.ipynb
@@ -651,16 +651,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "13200"
+       "18588"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -670,7 +670,7 @@
     "\n",
     "target = new_client.target\n",
     "activity = new_client.activity\n",
-    "herg = target.filter(pref_name__iexact='hERG').only('target_chembl_id')[0]\n",
+    "herg = target.filter(pref_name__iexact='Voltage-gated inwardly rectifying potassium channel KCNH2').only('target_chembl_id')[0]\n",
     "herg_activities = activity.filter(target_chembl_id=herg['target_chembl_id']).filter(standard_type=\"IC50\")\n",
     "\n",
     "len(herg_activities)"
@@ -1305,7 +1305,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -1319,7 +1319,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Rename target "hERG" to "Voltage-gated inwardly rectifying potassium channel KCNH2" to prevent `NoneType` error in Jupyter Notebook demo_wrc.ipynb. It seems that target was renamed in ChEMBL, so searching for "hERG" no longer produces any results, causing an error in the subsequent line.

Because Jupyter Notebook diffs can be confusing: the only meaningful difference in this PR is

```
herg = target.filter(pref_name__iexact='herg').only('target_chembl_id')[0]
```

is changed to

```
herg = target.filter(pref_name__iexact='Voltage-gated inwardly rectifying potassium channel KCNH2').only('target_chembl_id')[0]
```